### PR TITLE
Refactoring docker compose

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,12 +1,26 @@
- version: '2'
- services:
-   web:
-     build: .
-     ports:
-      - "8100"
-     environment:
-       REDIS_ENDPOINT: redis://redis:6379/0
-     depends_on:
+version: '2'
+services:
+  web:
+    container_name: functions_app_dev
+    build: .
+    ports:
+      - "127.0.0.1:8100:8100"
+    networks:
+      - functions_net_dev
+    environment:
+      REDIS_ENDPOINT: redis://redis:6379/0
+    depends_on:
       - redis
-   redis:
-     image: redis
+  redis:
+    container_name: functions_db_dev
+    image: redis
+    volumes:
+      - functions_vol_dev:/data
+    networks:
+      - functions_net_dev
+
+volumes:
+  functions_vol_dev:
+
+networks:
+  functions_net_dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,26 @@
- version: '2'
- services:
-   web:
-     image: globobackstage/functions
-     ports:
+version: '2'
+services:
+  web:
+    container_name: functions_app
+    image: globobackstage/functions
+    ports:
       - "8100:8100"
-     depends_on:
-      - redis
-     environment:
-       REDIS_ENDPOINT: redis://redis:6379/0
-   redis:
-     image: redis
+    networks:
+      - functions_net
+    depends_on:
+     - redis
+    environment:
+      REDIS_ENDPOINT: redis://redis:6379/0
+  redis:
+    container_name: functions_db
+    image: redis
+    volumes:
+      - functions_vol:/data
+    networks:
+      - functions_net
+
+volumes:
+  functions_vol:
+
+networks:
+  functions_net:


### PR DESCRIPTION
Hi, 

this pull request has the following contributions:

- Using a separated network. It will isolate containers from other containers in the same host machine
- Using volumes to persist redis. It will allow restart the service and do not loose data (stored functions). Also allowing external backups.
- At the development docker-compose the application only accepts requests from the 127.0.0.1. It protects and isolates the application from outside world.
- Both, development and productions, exposes the 8100 port at host machine.

PS: The YAML file indentation were updated to accept new mappings (volumes, networks). 


